### PR TITLE
Update target field for nerd-dinner and remove rules section

### DIFF
--- a/pkg/targets/tackle_hub.go
+++ b/pkg/targets/tackle_hub.go
@@ -530,6 +530,20 @@ func (t *TackleHubTarget) createAnalysisTask(ctx context.Context, test *config.T
 		taskData.Rules.Labels = ParseLabelSelector(test.Analysis.LabelSelector)
 	}
 
+	if len(test.Analysis.Target) != 0 || len(test.Analysis.Source) != 0 {
+		labels := []string{}
+		for _, s := range test.Analysis.Target {
+			labels = append(labels, fmt.Sprintf("konveyor.io/target=%s", s))
+		}
+		for _, s := range test.Analysis.Source {
+			labels = append(labels, fmt.Sprintf("konveyor.io/source=%s", s))
+		}
+		taskData.Rules.Labels = Labels{
+			Included: labels,
+		}
+	}
+	log.Info("Using labels", "labels", taskData.Rules.Labels, "source", test.Analysis.Source, "target", test.Analysis.Target, "selector", test.Analysis.LabelSelector)
+
 	// Handle rules that may be Git URLs
 	// Tackle Hub uses repositories for rules, so we'll prepare them differently
 	err := t.prepareRulesForHub(ctx, test, &taskData)

--- a/tests/nerd-dinner/expected-output.yaml
+++ b/tests/nerd-dinner/expected-output.yaml
@@ -1,3 +1,49 @@
+- name: discovery-rules
+  tags:
+  - License=BSD License
+  insights:
+    discover-license:
+      description: Discover project license
+      labels:
+      - discovery
+      - konveyor.io/include=always
+      - konveyor.io/target=discovery
+      - tag=License=BSD License
+      incidents:
+      - uri: file:///source/testdata/nerd-dinner/mvc4/NerdDinner/Scripts/jquery-1.7.1-vsdoc.js
+        message: ""
+        codeSnip: 40  *
+        lineNumber: 39
+        variables:
+          matchingText: BSD License
+      - uri: file:///source/testdata/nerd-dinner/mvc4/NerdDinner/Scripts/jquery-1.7.1.js
+        message: ""
+        codeSnip: 13   *
+        lineNumber: 12
+        variables:
+          matchingText: BSD License
+      - uri: file:///source/testdata/nerd-dinner/packages/jQuery/Content/Scripts/jquery-1.7.1-vsdoc.js
+        message: ""
+        codeSnip: 40  *
+        lineNumber: 39
+        variables:
+          matchingText: BSD License
+      - uri: file:///source/testdata/nerd-dinner/packages/jQuery/Content/Scripts/jquery-1.7.1.js
+        message: ""
+        codeSnip: 13   *
+        lineNumber: 12
+        variables:
+          matchingText: BSD License
+  unmatched:
+  - discover-java-files
+  - discover-manifest-file
+  - discover-maven-xml
+  - discover-properties-file
+  - hardcoded-ip-address
+  - windup-discover-ejb-configuration
+  - windup-discover-jpa-configuration
+  - windup-discover-spring-configuration
+  - windup-discover-web-configuration
 - name: dotnet-core-migration
   description: |
     Ruleset for migrating ASP.NET MVC applications to ASP.NET Core / .NET Core.

--- a/tests/nerd-dinner/test.yaml
+++ b/tests/nerd-dinner/test.yaml
@@ -4,10 +4,8 @@ analysis:
     context_lines: 0
     incident_selector: ""
     source: []
-    target: []
-    rules:
-      - git:
-          gitRepo: https://github.com/konveyor/c-sharp-analyzer-provider#main/rulesets/dotnet-core-migration
+    target:
+    - dotnet-core
     disableDefaultRules: true
     analysisMode: source-only
 timeout: 10m0s

--- a/tests/nerd-dinner/test.yaml
+++ b/tests/nerd-dinner/test.yaml
@@ -6,7 +6,7 @@ analysis:
     source: []
     target:
     - dotnet-core
-    disableDefaultRules: true
+    disableDefaultRules: false
     analysisMode: source-only
 timeout: 10m0s
 expect:

--- a/tests/nerd-dinner/test.yaml
+++ b/tests/nerd-dinner/test.yaml
@@ -5,7 +5,8 @@ analysis:
     incident_selector: ""
     source: []
     target:
-    - dotnet-core
+      - dotnet-core
+    rules: []
     disableDefaultRules: false
     analysisMode: source-only
 timeout: 10m0s


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched analysis to use the built-in "dotnet-core" target and re-enabled default rules so standard checks run by default.
* **New Features**
  * Improved task labeling so analysis tasks include source/target labels for clearer task classification.
* **Tests**
  * Updated expected output to include a discovery ruleset that captures license discoveries and related sample incidents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->