### PR TITLE
:bug: adding back OpenMRS to test with updates to kantra to enable local-m2…

### DIFF
--- a/.github/workflows/kantra.yaml
+++ b/.github/workflows/kantra.yaml
@@ -41,7 +41,7 @@ jobs:
           choco install podman-cli
           podman machine init --rootful --memory 10240 --cpus 3
           podman machine start 
-          podman cp $(podman create --name kantra-download quay.io/konveyor/kantra:latest):/usr/local/bin/windows-kantra . &&\
+          podman cp $(podman create --name kantra-download quay.io/shawn_hurley/kantra:testing-image):/usr/local/bin/windows-kantra . &&\
           podman rm kantra-download
           cp windows-kantra $HOME/.local/bin/kantra.exe
           ls -la $HOME/.local/bin/kantra.exe

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -109,6 +109,10 @@ func NormalizePath(path string) string {
 	if strings.Contains(path, "/root/.m2/repository") {
 		path = strings.ReplaceAll(path, "/root/.m2/repository/", "/m2/")
 	}
+	if strings.Contains(path, "/opt/input/maven-cache/repository") {
+		path = strings.ReplaceAll(path, "/opt/input/maven-cache/repository/", "/m2/")
+	}
+
 	if strings.Contains(path, "/cache/m2/") {
 		path = strings.ReplaceAll(path, "/cache/m2/", "/m2/")
 	}

--- a/tests/acmeair-webapp/test.yaml
+++ b/tests/acmeair-webapp/test.yaml
@@ -3,7 +3,6 @@ description: Binary analysis of acmeair webapp WAR file
 analysis:
     application: acmeair-webapp-1.0-SNAPSHOT.war
     labelSelector: konveyor.io/target=cloud-readiness || konveyor.io/target=jakarta-ee
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -11,6 +10,7 @@ analysis:
     rules: []
     disableDefaultRules: false
     analysisMode: full
+    logLevel: 9
 timeout: 10m0s
 expect:
     exitCode: 0

--- a/tests/book-server-deps/test.yaml
+++ b/tests/book-server-deps/test.yaml
@@ -3,13 +3,13 @@ analysis:
     application: https://github.com/konveyor-ecosystem/book-server#ci-oct2025
     labelSelector: konveyor.io/target=cloud-readiness || konveyor.io/target=quarkus
     context_lines: 0
-    logLevel: 9
     incident_selector: ""
     source: []
     target: []
     rules: []
     disableDefaultRules: false
     analysisMode: source-only
+    logLevel: 9
 timeout: 10m0s
 expect:
     exitCode: 0

--- a/tests/coolstore-source-and-dependencies/test.yaml
+++ b/tests/coolstore-source-and-dependencies/test.yaml
@@ -2,7 +2,6 @@ name: Coolstore-Source and dependencies
 analysis:
     application: https://github.com/konveyor-ecosystem/coolstore#ci-2024
     labelSelector: konveyor.io/target=cloud-readiness || konveyor.io/target=jakarta-ee
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -10,6 +9,7 @@ analysis:
     rules: []
     disableDefaultRules: false
     analysisMode: source-only
+    logLevel: 9
 timeout: 15m0s
 expect:
     exitCode: 0

--- a/tests/daytrader/test.yaml
+++ b/tests/daytrader/test.yaml
@@ -3,7 +3,6 @@ description: Daytrader 7 EE application
 analysis:
     application: https://github.com/konveyor-ecosystem/sample.daytrader7.git#ci-oct2025
     labelSelector: konveyor.io/target=cloud-readiness || konveyor.io/target=quarkus
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -11,6 +10,7 @@ analysis:
     rules: []
     disableDefaultRules: false
     analysisMode: source-only
+    logLevel: 9
 timeout: 10m0s
 expect:
     exitCode: 0

--- a/tests/nerd-dinner/test.yaml
+++ b/tests/nerd-dinner/test.yaml
@@ -5,7 +5,7 @@ analysis:
     incident_selector: ""
     source: []
     target:
-      - dotnet-core
+        - dotnet-core
     rules: []
     disableDefaultRules: false
     analysisMode: source-only

--- a/tests/openmrs/test.yaml
+++ b/tests/openmrs/test.yaml
@@ -1,6 +1,3 @@
-# SKIPPED: Skip test due to a known issue on Windows.
-# For more information, see https://github.com/konveyor/kantra/issues/806
-
 name: OpenMRS Source Analysis
 description: Source analysis of OpenMRS core application
 analysis:

--- a/tests/openmrs/test.yaml
+++ b/tests/openmrs/test.yaml
@@ -3,7 +3,6 @@ description: Source analysis of OpenMRS core application
 analysis:
     application: https://github.com/migtools/openmrs-core#koncur-ci-2026
     labelSelector: konveyor.io/target=openjdk
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -11,6 +10,7 @@ analysis:
     rules: []
     disableDefaultRules: false
     analysisMode: source-only
+    logLevel: 9
 timeout: 30m0s
 expect:
     exitCode: 0

--- a/tests/python-sample/expected-output.yaml
+++ b/tests/python-sample/expected-output.yaml
@@ -1,7 +1,7 @@
 - name: konveyor-analysis
   violations:
     python-sample-rule-001:
-      description: ""
+      description: sample-rule-1 - this should appear as an issue
       category: potential
       incidents:
       - uri: file:///source/file_a.py
@@ -11,7 +11,7 @@
           file: file:///opt/input/source/file_a.py
       effort: 1
     python-sample-rule-002:
-      description: ""
+      description: sample-rule-2 - this should appear as an issue
       category: potential
       incidents:
       - uri: file:///source/file_a.py

--- a/tests/python-sample/test.yaml
+++ b/tests/python-sample/test.yaml
@@ -6,8 +6,9 @@ analysis:
     source: []
     target: []
     rules:
-      - file:
-          filePath: rule-example.yaml
+        - file:
+            filePath: rule-example.yaml
+          git: null
     disableDefaultRules: true
     analysisMode: source-only
 timeout: 10m0s

--- a/tests/seam-booking/test.yaml
+++ b/tests/seam-booking/test.yaml
@@ -3,13 +3,13 @@ analysis:
     application: https://github.com/konveyor-ecosystem/windup.git#ci-2024/test-files/seam-booking-5.2
     labelSelector: konveyor.io/target=eap
     context_lines: 0
-    logLevel: 9
     incident_selector: ""
     source: []
     target: []
     rules: []
     disableDefaultRules: false
     analysisMode: source-only
+    logLevel: 9
 timeout: 10m0s
 expect:
     exitCode: 0

--- a/tests/tackle-testapp-with-custom-rules/test.yaml
+++ b/tests/tackle-testapp-with-custom-rules/test.yaml
@@ -2,7 +2,6 @@ name: Tackle Testapp with custom rules
 analysis:
     application: https://github.com/konveyor/tackle-testapp-public#ci-2024
     labelSelector: konveyor.io/source=java && (konveyor.io/target=phil || konveyor.io/target=phil7)
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -13,6 +12,7 @@ analysis:
           git: null
     disableDefaultRules: false
     analysisMode: full
+    logLevel: 9
 timeout: 10m0s
 requireMavenSettings: true
 expect:

--- a/tests/tackle-testapp-with-deps/expected-output.yaml
+++ b/tests/tackle-testapp-with-deps/expected-output.yaml
@@ -25,7 +25,7 @@
           {\n11  Properties properties = new Properties();\n12  \n13  try {"
         lineNumber: 3
         variables:
-          file: file:///addon/.m2/repository/io/konveyor/demo/configuration-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
+          file: file:///opt/input/maven-cache/repository/io/konveyor/demo/configuration-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
           kind: Class
           name: ApplicationConfiguration
           package: io.konveyor.demo.config
@@ -43,7 +43,7 @@
           {\n22  var6.addSuppressed(var5);\n23  }\n24  "
         lineNumber: 14
         variables:
-          file: file:///addon/.m2/repository/io/konveyor/demo/configuration-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
+          file: file:///opt/input/maven-cache/repository/io/konveyor/demo/configuration-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
           kind: Method
           name: loadProperties
           package: io.konveyor.demo.config
@@ -657,7 +657,7 @@
           {\n22  var6.addSuppressed(var5);\n23  }\n24  "
         lineNumber: 14
         variables:
-          file: file:///addon/.m2/repository/io/konveyor/demo/configuration-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
+          file: file:///opt/input/maven-cache/repository/io/konveyor/demo/configuration-utils/1.0.0/io/konveyor/demo/config/ApplicationConfiguration.java
           kind: Constructor
           name: loadProperties
           package: io.konveyor.demo.config

--- a/tests/tackle-testapp-with-deps/test.yaml
+++ b/tests/tackle-testapp-with-deps/test.yaml
@@ -2,7 +2,6 @@ name: Tackle Testapp public with deps
 analysis:
     application: https://github.com/konveyor/tackle-testapp-public#ci-2024
     labelSelector: konveyor.io/target
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -10,6 +9,7 @@ analysis:
     rules: []
     disableDefaultRules: false
     analysisMode: full
+    logLevel: 9
 timeout: 10m0s
 requireMavenSettings: true
 expect:

--- a/tests/tomcat-legacy/test.yaml
+++ b/tests/tomcat-legacy/test.yaml
@@ -2,7 +2,6 @@ name: Customer Tomcat Legacy - shoud never fail
 analysis:
     application: https://github.com/konveyor/example-applications.git#ci-2023/example-1
     labelSelector: konveyor.io/target=cloud-readiness || konveyor.io/target=linux
-    logLevel: 9
     context_lines: 0
     incident_selector: ""
     source: []
@@ -10,6 +9,7 @@ analysis:
     rules: []
     disableDefaultRules: false
     analysisMode: source-only
+    logLevel: 9
 timeout: 10m0s
 expect:
     exitCode: 0


### PR DESCRIPTION
…-dir

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reordered logLevel entries in multiple test configs (no behavioral change).
  * Adjusted one test's target indentation affecting .NET target shape.
  * Updated expected-output descriptions and some expected Maven-cache paths.
  * Tweaked a test rule entry to include an explicit git field.

* **Bug Fixes**
  * Canonicalized additional Maven repository path variants for consistent handling.

* **Chores**
  * Updated Windows Kantra download/source used by CI for installing the Kantra executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->