### PR TITLE
:sparkles: Migrate from Keycloak to hub built-in OIDC auth

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,13 +85,11 @@ kind-delete: ## Delete the Kind cluster
 ##@ Tackle Hub Installation
 
 AUTH_ENABLED ?= false
-TACKLE_ADMIN_USER ?= admin
-TACKLE_ADMIN_PASS ?= Passw0rd!
 
 hub-install: ## Install Tackle Hub on the Kind cluster (auth disabled)
 	@$(MAKE) _hub-install AUTH_ENABLED=false
 
-hub-install-auth: ## Install Tackle Hub with authentication enabled
+hub-install-auth: ## Install Tackle Hub with authentication enabled (hub seeds default user admin/admin)
 	@$(MAKE) _hub-install AUTH_ENABLED=true
 
 _hub-install: ## Internal target for hub installation
@@ -170,64 +168,15 @@ _hub-install: ## Internal target for hub installation
 	@echo "Waiting for Tackle Hub to be ready (this may take a few minutes)..."
 	@sleep 30
 	@$(KUBECTL) wait --for=condition=ready pod -l app.kubernetes.io/name=tackle-hub -n ${KONVEYOR_NAMESPACE} --timeout=600s || true
-	@echo "Waiting for Tackle Hub to be ready (this may take a few minutes)..."
-	@sleep 30
-	@$(KUBECTL) wait --for=condition=ready pod -l app.kubernetes.io/name=tackle-hub -n ${KONVEYOR_NAMESPACE} --timeout=600s || true
-	@if [ "$(AUTH_ENABLED)" = "true" ]; then \
-		echo "Waiting for Keycloak deployment to be created..."; \
-		for i in $$(seq 1 120); do \
-			$(KUBECTL) get deployment tackle-keycloak-sso -n ${KONVEYOR_NAMESPACE} >/dev/null 2>&1 && break || sleep 5; \
-			if [ $$i -eq 120 ]; then echo "Timeout waiting for Keycloak deployment"; exit 1; fi; \
-		done; \
-		echo "Waiting for Keycloak to be ready..."; \
-		$(KUBECTL) wait --for=condition=ready pod -l app.kubernetes.io/name=tackle-keycloak-sso -n ${KONVEYOR_NAMESPACE} --timeout=600s; \
-		echo "Waiting for tackle ingress to be created..."; \
-		for i in $$(seq 1 60); do \
-			$(KUBECTL) get ingress tackle -n ${KONVEYOR_NAMESPACE} >/dev/null 2>&1 && break || sleep 5; \
-			if [ $$i -eq 60 ]; then echo "Timeout waiting for tackle ingress"; exit 1; fi; \
-		done; \
-		echo "Creating NetworkPolicy to allow ingress-nginx to reach Keycloak..."; \
-		printf 'apiVersion: networking.k8s.io/v1\nkind: NetworkPolicy\nmetadata:\n  name: tackle-keycloak-ingress\n  namespace: ${KONVEYOR_NAMESPACE}\n  labels:\n    app: tackle\nspec:\n  podSelector:\n    matchLabels:\n      role: tackle-keycloak-sso\n  policyTypes:\n  - Ingress\n  ingress:\n  - from:\n    - namespaceSelector:\n        matchLabels:\n          kubernetes.io/metadata.name: ingress-nginx\n    ports:\n    - port: 8080\n      protocol: TCP\n    - port: 8443\n      protocol: TCP\n' | $(KUBECTL) apply -f -; \
-		echo "Configuring Keycloak hostname for https://localhost:$(HOST_PORT_TLS)/auth..."; \
-		$(KUBECTL) set env deployment/tackle-keycloak-sso -n ${KONVEYOR_NAMESPACE} \
-			KC_HOSTNAME=https://localhost:$(HOST_PORT_TLS)/auth \
-			KC_HOSTNAME_BACKCHANNEL_DYNAMIC=true; \
-		$(KUBECTL) patch deployment tackle-keycloak-sso -n ${KONVEYOR_NAMESPACE} --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/args", "value": ["-Djgroups.dns.query=mta-kc-discovery.openshift-mta", "--verbose", "start", "--hostname=https://localhost:$(HOST_PORT_TLS)/auth", "--hostname-backchannel-dynamic=true"]}]'; \
-		echo "Waiting for Keycloak to restart with new configuration..."; \
-		$(KUBECTL) rollout status deployment/tackle-keycloak-sso -n ${KONVEYOR_NAMESPACE} --timeout=180s; \
-		$(KUBECTL) set env deployment/tackle-hub -n ${KONVEYOR_NAMESPACE} KEYCLOAK_REQ_PASS_UPDATE=false; \
-		$(KUBECTL) rollout status deployment/tackle-hub -n ${KONVEYOR_NAMESPACE} --timeout=120s; \
-		KC_POD=$$($(KUBECTL) get pods -n ${KONVEYOR_NAMESPACE} -l app.kubernetes.io/name=tackle-keycloak-sso -o jsonpath='{.items[0].metadata.name}'); \
-		KC_PASS=$$($(KUBECTL) get secret tackle-keycloak-sso -n ${KONVEYOR_NAMESPACE} -o jsonpath='{.data.password}' | base64 -d); \
-		$(KUBECTL) exec -n ${KONVEYOR_NAMESPACE} $$KC_POD -- /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user admin --password "$$KC_PASS"; \
-		echo "Waiting for admin user to be created in Keycloak..."; \
-		ADMIN_USER_ID=""; \
-		for i in $$(seq 1 30); do \
-			ADMIN_USER_ID=$$($(KUBECTL) exec -n ${KONVEYOR_NAMESPACE} $$KC_POD -- /opt/keycloak/bin/kcadm.sh get users -r tackle -q username=$(TACKLE_ADMIN_USER) --fields id 2>/dev/null | grep -o '"id" *: *"[^"]*"' | cut -d'"' -f4); \
-			if [ -n "$$ADMIN_USER_ID" ]; then \
-				break; \
-			fi; \
-			echo "  Admin user not yet created, waiting 5s..."; \
-			sleep 5; \
-		done; \
-		if [ -n "$$ADMIN_USER_ID" ]; then \
-			$(KUBECTL) exec -n ${KONVEYOR_NAMESPACE} $$KC_POD -- /opt/keycloak/bin/kcadm.sh update users/$$ADMIN_USER_ID -r tackle -s 'requiredActions=[]'; \
-		else \
-			echo "Error: Admin user '$(TACKLE_ADMIN_USER)' was not created in Keycloak after 150s."; \
-			exit 1; \
-		fi; \
-	fi
 	@echo ""
 	@echo "Tackle Hub installation complete!"
 	@echo ""
 	@if $(KUBECTL) get pods -n ingress-nginx --no-headers 2>/dev/null | grep -q ingress-nginx-controller; then \
-		if [ "$(AUTH_ENABLED)" = "true" ]; then \
-			echo "Access Tackle Hub via ingress at: https://localhost:$(HOST_PORT_TLS)"; \
-			echo "(Auth enabled - HTTPS with self-signed certificate)"; \
-		else \
-			echo "Access Tackle Hub via ingress at: http://localhost:$(HOST_PORT)"; \
-		fi; \
+		echo "Access Tackle Hub via ingress at: http://localhost:$(HOST_PORT)"; \
 		echo ""; \
+	fi
+	@if [ "$(AUTH_ENABLED)" = "true" ]; then \
+		echo "Auth is enabled - the hub's built-in OIDC provider seeds default user admin/admin"; \
 	fi
 	@echo "Or run 'make hub-forward' to access via port-forward at :8081"
 	@echo "Run 'make hub-status' to check the status"
@@ -322,18 +271,18 @@ setup: kind-create hub-install build ## Complete setup: create cluster, install 
 	@echo "2. In another terminal, run: make test-hub"
 	@echo ""
 
-setup-auth: kind-create hub-install-auth build ## Complete setup with auth: create cluster, install hub with Keycloak, build binary
+setup-auth: kind-create hub-install-auth build ## Complete setup with auth: create cluster, install hub with auth required, build binary
 	@echo ""
 	@echo "=========================================="
 	@echo "Auth setup complete!"
 	@echo "=========================================="
 	@echo ""
-	@echo "Access: https://localhost:$(HOST_PORT_TLS)"
-	@echo "  User: $(TACKLE_ADMIN_USER)"
-	@echo "  Pass: Passw0rd!
+	@echo "1. In one terminal, run: make hub-forward"
+	@echo "2. Access the hub at: http://localhost:8081"
+	@echo "  User: admin"
+	@echo "  Pass: admin"
 	@echo ""
-	@echo "Note: Uses a self-signed certificate. Accept the browser warning to proceed."
-	@echo "      Password is from the tackle-keycloak-sso secret in $(KONVEYOR_NAMESPACE)."
+	@echo "Note: Credentials are the defaults seeded by the hub's built-in OIDC provider."
 	@echo ""
 
 teardown: hub-uninstall kind-delete ## Complete teardown: uninstall hub, delete cluster

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Once setup is complete, Tackle Hub is accessible via:
 
 **Ingress (HTTP):**
 - Hub API: `http://localhost:8080/hub`
-- Hub UI: `http://localhost:8080/hub`
+- Hub UI: `http://localhost:8080`
 
 **Port-forward (alternative):**
 ```bash

--- a/README.md
+++ b/README.md
@@ -299,50 +299,43 @@ make setup
 
 ### Quick Setup (With Auth)
 
-To install Tackle Hub with Keycloak authentication enabled:
+To install Tackle Hub with authentication enabled:
 
 ```bash
-# Complete setup with auth: create cluster, install hub with Keycloak, build binary
+# Complete setup with auth: create cluster, install hub with auth required, build binary
 make setup-auth
 
 # This runs:
 # 1. make kind-create       - Creates Kind cluster with ingress
-# 2. make hub-install-auth  - Installs Tackle Hub with Keycloak (auth enabled)
+# 2. make hub-install-auth  - Installs Tackle Hub with auth required
 # 3. make build             - Builds the koncur binary
 ```
 
-When auth is enabled, the setup:
-- Deploys Keycloak SSO alongside Tackle Hub
-- Configures Keycloak hostname for `https://localhost:8443/auth`
-- Creates a NetworkPolicy to allow ingress traffic to Keycloak
-- Provisions an admin user with password from the `tackle-keycloak-sso` secret
-- Serves Tackle Hub over HTTPS with a self-signed certificate
+The hub provides its own built-in OIDC provider — no separate identity server
+is deployed. Enabling auth just sets `feature_auth_required: "true"` on the
+Tackle CR, which makes the hub reject unauthenticated API requests.
 
-**Default credentials:**
+**Default credentials** (seeded by the hub's built-in OIDC provider):
 - Username: `admin`
-- Password: `Passw0rd!`
-
-The Tackle application user password (`Passw0rd!`) is set by the hub when it
-seeds the admin user into Keycloak. This is separate from the Keycloak server
-admin password stored in the `tackle-keycloak-sso` secret.
+- Password: `admin`
 
 ### Accessing Tackle Hub
 
 Once setup is complete, Tackle Hub is accessible via:
 
-**Without auth (HTTP):**
+**Ingress (HTTP):**
 - Hub API: `http://localhost:8080/hub`
 - Hub UI: `http://localhost:8080/hub`
 
-**With auth (HTTPS):**
-- Hub: `https://localhost:8443`
-- Accept the self-signed certificate warning in your browser
-
-**Port-forward (alternative, works for both):**
+**Port-forward (alternative):**
 ```bash
 make hub-forward
 # Hub will be available at http://localhost:8081
 ```
+
+Access is the same with or without auth; when auth is enabled, API requests
+must authenticate (koncur uses HTTP Basic auth with the credentials from the
+target config).
 
 ### Running Tests
 
@@ -374,7 +367,7 @@ See [Local Testing with Custom Images](docs/local-testing-custom-images.md) for 
 
 **Setup & Teardown:**
 - `make setup` - Complete setup (cluster + hub + build, no auth)
-- `make setup-auth` - Complete setup with Keycloak authentication
+- `make setup-auth` - Complete setup with authentication required
 - `make teardown` - Complete teardown (uninstall hub + delete cluster)
 
 **Cluster Management:**
@@ -383,7 +376,7 @@ See [Local Testing with Custom Images](docs/local-testing-custom-images.md) for 
 
 **Tackle Hub:**
 - `make hub-install` - Install Tackle Hub with auth disabled
-- `make hub-install-auth` - Install Tackle Hub with Keycloak auth enabled
+- `make hub-install-auth` - Install Tackle Hub with auth required (built-in OIDC, admin/admin)
 - `make hub-uninstall` - Uninstall Tackle Hub
 - `make hub-status` - Check Tackle Hub status
 - `make hub-forward` - Port-forward to access Hub at :8081
@@ -460,20 +453,21 @@ tackleHub:
 ```
 
 **With auth** - when using `make setup-auth`, the target config must include
-`username`, `password`, and `insecure: true` (for the self-signed certificate):
+`username` and `password` (koncur authenticates with HTTP Basic auth):
 
 ```yaml
 type: tackle-hub
 tackleHub:
-  url: https://localhost:8443/hub
+  url: http://localhost:8080/hub
   username: admin
-  password: "Passw0rd!"
-  insecure: true
+  password: admin
   mavenSettings: settings.xml
 ```
 
-The `insecure: true` field tells koncur to skip TLS certificate verification,
-which is required because the Kind cluster uses a self-signed certificate.
+A `token` may be provided instead of `username`/`password` to authenticate
+with a bearer token (e.g. a hub personal access token). When targeting a
+remote hub served over HTTPS with a self-signed certificate, set
+`insecure: true` to skip TLS verification.
 
 ### What Gets Installed
 
@@ -489,14 +483,10 @@ The `make hub-install` target automatically:
 4. **Patches ingress** to disable SSL redirect (allows HTTP access at `http://localhost:8080`)
 5. **Waits for readiness** with automatic health checks
 
-The `make hub-install-auth` target does all of the above, plus:
-
-1. **Enables authentication** (`feature_auth_required: "true"`)
-2. **Deploys Keycloak SSO** and waits for it to become ready
-3. **Creates a NetworkPolicy** allowing ingress-nginx to reach Keycloak
-4. **Configures Keycloak hostname** for `https://localhost:8443/auth` with backchannel dynamic routing
-5. **Disables forced password update** so the admin user can log in immediately
-6. **Provisions the admin user** in the `tackle` realm and clears any required actions
+The `make hub-install-auth` target does all of the above, but sets
+`feature_auth_required: "true"` on the Tackle CR instead. The hub's built-in
+OIDC provider seeds a default `admin`/`admin` user at startup — no additional
+setup is required.
 
 ### Troubleshooting
 
@@ -517,21 +507,11 @@ The `make hub-install-auth` target does all of the above, plus:
 - Check pod status: `make hub-status`
 - View pod logs: `kubectl logs -n konveyor-tackle -l app.kubernetes.io/name=tackle-hub`
 
-**Auth setup: Keycloak or Hub unreachable via ingress:**
-- The ingress-nginx controller may need to be restarted after Tackle and Keycloak
-  ingress resources are created. Delete the controller pod and let Kubernetes
-  recreate it:
-  ```bash
-  kubectl delete pod -n ingress-nginx -l app.kubernetes.io/component=controller
-  ```
-- Wait for the new pod to become ready:
-  ```bash
-  kubectl wait --namespace ingress-nginx \
-    --for=condition=ready pod \
-    --selector=app.kubernetes.io/component=controller \
-    --timeout=120s
-  ```
-- Then verify you can reach the Hub at `https://localhost:8443`
+**Auth setup: requests failing with 401:**
+- Verify the target config includes `username: admin` / `password: admin`
+  (or a valid `token`)
+- Confirm auth is enforced: `curl -s -o /dev/null -w '%{http_code}' http://localhost:8081/applications`
+  should return `401` without credentials and `200` with `-u admin:admin`
 
 ## License
 

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -121,7 +121,7 @@ type: tackle-hub
 tackleHub:
   url: http://localhost:8081
   username: admin
-  password: Passw0rd!
+  password: admin
   mavenSettings: /home/user/.m2/settings.xml
 ```
 
@@ -186,7 +186,7 @@ type: tackle-ui
 tackleUI:
   url: http://localhost:8080
   username: admin
-  password: Passw0rd!
+  password: admin
   browser: chrome
   headless: true
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-playground/validator/v10 v10.19.0
 	github.com/konveyor/analyzer-lsp v0.9.0-alpha.4.0.20260114161359-66c14bb2dcc7
-	github.com/konveyor/tackle2-hub/shared v0.0.0-20260306231449-91eaaa65805c
+	github.com/konveyor/tackle2-hub/shared v0.0.0-20260702101118-eb4916ced49d
 	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.9.1
 	go.lsp.dev/uri v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,8 @@ github.com/jortel/go-utils v0.1.5 h1:fBkvlojnbrx5rqJt+1fx9dlGV5NjjnCyGgWyXsQ12Ws
 github.com/jortel/go-utils v0.1.5/go.mod h1:R9W67T6eTYPcofmSuvvv3lOcNuF4zh7ZoBfaoTA9zss=
 github.com/konveyor/analyzer-lsp v0.9.0-alpha.4.0.20260114161359-66c14bb2dcc7 h1:mqPbHo6mmLGhZ11wGuL8M9Qr+hvNdaiOO/iMK6c2jIU=
 github.com/konveyor/analyzer-lsp v0.9.0-alpha.4.0.20260114161359-66c14bb2dcc7/go.mod h1:V97MK7UPGXzFJaM1pXs887+5sB7Yuu3moR58Xl9j1N0=
-github.com/konveyor/tackle2-hub/shared v0.0.0-20260204150237-77c448c3926f h1:RTkcIc/AQW8kRcu8VBPNisZykaQ7OboJZDym66rHRFU=
-github.com/konveyor/tackle2-hub/shared v0.0.0-20260204150237-77c448c3926f/go.mod h1:kJBH9U7Lcn7p3o0etF7O2S6dnERX50ekAfi2PCwKyng=
-github.com/konveyor/tackle2-hub/shared v0.0.0-20260306231449-91eaaa65805c h1:AoiexD/pgwB26f5p/iMjwmiNyU3tKdzoC1RGCNcGfx8=
-github.com/konveyor/tackle2-hub/shared v0.0.0-20260306231449-91eaaa65805c/go.mod h1:kJBH9U7Lcn7p3o0etF7O2S6dnERX50ekAfi2PCwKyng=
+github.com/konveyor/tackle2-hub/shared v0.0.0-20260702101118-eb4916ced49d h1:QqQZWuDDIAhcW8Do9ap2xfyD7YoZpmXp6oMjHxwYWKc=
+github.com/konveyor/tackle2-hub/shared v0.0.0-20260702101118-eb4916ced49d/go.mod h1:kJBH9U7Lcn7p3o0etF7O2S6dnERX50ekAfi2PCwKyng=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/pkg/targets/tackle_hub.go
+++ b/pkg/targets/tackle_hub.go
@@ -127,6 +127,8 @@ func NewTackleHubTarget(cfg *config.TackleHubConfig) (*TackleHubTarget, error) {
 	} else if cfg.Username != "" && cfg.Password != "" {
 		client.Client.Use(auth.NewBasic(cfg.Username, cfg.Password))
 		hasCredentials = true
+	} else if cfg.Username != "" || cfg.Password != "" {
+		return nil, fmt.Errorf("both username and password are required when either is set")
 	}
 	// If no credentials provided, assume auth is disabled on the Tackle instance
 

--- a/pkg/targets/tackle_hub.go
+++ b/pkg/targets/tackle_hub.go
@@ -14,6 +14,7 @@ import (
 	konveyor "github.com/konveyor/analyzer-lsp/output/v1/konveyor"
 	"github.com/konveyor/tackle2-hub/shared/api"
 	"github.com/konveyor/tackle2-hub/shared/binding"
+	"github.com/konveyor/tackle2-hub/shared/binding/auth"
 	"github.com/konveyor/test-harness/pkg/config"
 	"github.com/konveyor/test-harness/pkg/parser"
 	"github.com/konveyor/test-harness/pkg/util"
@@ -119,15 +120,24 @@ func NewTackleHubTarget(cfg *config.TackleHubConfig) (*TackleHubTarget, error) {
 	}
 
 	// Set authentication if provided (optional for instances with auth disabled)
+	hasCredentials := false
 	if cfg.Token != "" {
-		client.Client.Use(api.Login{Token: cfg.Token})
+		client.Client.Use(auth.NewBearer(cfg.Token))
+		hasCredentials = true
 	} else if cfg.Username != "" && cfg.Password != "" {
-		err := client.Login(cfg.Username, cfg.Password)
+		client.Client.Use(auth.NewBasic(cfg.Username, cfg.Password))
+		hasCredentials = true
+	}
+	// If no credentials provided, assume auth is disabled on the Tackle instance
+
+	// Auth is applied lazily per-request; probe the API so bad credentials
+	// fail here rather than mid-test.
+	if hasCredentials {
+		_, err := client.Application.List()
 		if err != nil {
 			return nil, fmt.Errorf("failed to login: %w", err)
 		}
 	}
-	// If no credentials provided, assume auth is disabled on the Tackle instance
 
 	return &TackleHubTarget{
 		url:           cfg.URL,


### PR DESCRIPTION
## Summary

The hub replaced Keycloak with a built-in OIDC provider (konveyor/tackle2-hub@518efef) and the operator no longer deploys Keycloak (konveyor/tackle2-operator#567). Koncur's auth-enabled install path still waited on a `tackle-keycloak-sso` deployment that never appears, so `make hub-install-auth` (and the CI jobs that use it) timed out.

## Changes

- **Makefile**: drop the entire Keycloak wait/configure/kcadm block from `_hub-install`; `feature_auth_required` on the Tackle CR is now the whole auth setup. The hub seeds a default `admin`/`admin` user, so `TACKLE_ADMIN_USER`/`TACKLE_ADMIN_PASS` are removed. Auth access is now identical to no-auth (plain HTTP via ingress or port-forward).
- **Go**: bump `tackle2-hub/shared` past the auth transition and migrate from the removed `RichClient.Login()`/`api.Login` to the new `shared/binding/auth` package (Basic for username/password, Bearer for token). When credentials are configured, probe the API at target construction so bad credentials fail fast like the old eager login did.
- **Docs**: replace Keycloak/self-signed-TLS instructions with the built-in OIDC model.

## Testing

- `go build ./...` passes (the `go vet` failure in `kantra_test.go:801` pre-exists on main)
- `make -n hub-install-auth` / `make -n setup-auth` parse
- Companion konveyor/ci PR updates the `koncur-tackle-hub` action to match and exercises this end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated authenticated Hub setup to use the built-in OIDC-seeded default login (`admin/admin`) instead of a separate Keycloak flow.
  - Added support for both bearer-token and username/password authentication during Hub access.

- **Bug Fixes**
  - Simplified auth-enabled setup output and removed outdated credential prompts.
  - Improved startup handling so invalid credentials fail earlier.

- **Documentation**
  - Revised setup, configuration, and troubleshooting guides to match the new authentication flow and default credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->