### PR TITLE
Pin podman-cli to v5.8.1 on Windows

### DIFF
--- a/.github/workflows/kantra-local.yaml
+++ b/.github/workflows/kantra-local.yaml
@@ -62,7 +62,8 @@ jobs:
         if: ${{ inputs.os == 'windows-latest' }}
         shell: bash
         run: |
-          choco install podman-cli
+          # Pinned to 5.8.1 to work around SSH connection failures with Podman 6.0 on Windows
+          choco install podman-cli --version=5.8.1
           podman machine init --rootful --memory 10240 --cpus 3
           podman machine start 
           CID=$(podman create quay.io/konveyor/kantra:${{ inputs.image_tag }})

--- a/.github/workflows/kantra.yaml
+++ b/.github/workflows/kantra.yaml
@@ -42,7 +42,8 @@ jobs:
         if: ${{ inputs.os == 'windows-latest' }}
         shell: bash
         run: |
-          choco install podman-cli
+          # Pinned to 5.8.1 to work around SSH connection failures with Podman 6.0 on Windows
+          choco install podman-cli --version=5.8.1
           podman machine init --rootful --memory 10240 --cpus 3
           podman machine start 
           podman cp $(podman create --name kantra-download quay.io/konveyor/kantra:${{ inputs.image_tag }}):/usr/local/bin/windows-kantra . &&\


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows workflow reliability by pinning a Podman CLI version, helping avoid SSH connection failures during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->