### PR TITLE
:bug: Fix flaky hub validation of synthesized discovery rulesets; run unit tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,22 @@ on:
       - "release-*"
 
 jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Run unit tests
+        run: go test ./...
+
   setup:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,12 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/pkg/config/git_url_test.go
+++ b/pkg/config/git_url_test.go
@@ -118,47 +118,34 @@ func TestAnalysisConfig_ParseGitURLs(t *testing.T) {
 		name        string
 		config      AnalysisConfig
 		wantAppComp *GitURLComponents
-		wantRules   int
 	}{
 		{
-			name: "Git application and mixed rules",
+			name: "Git application with branch and path",
 			config: AnalysisConfig{
 				Application: "https://github.com/konveyor/app#main/src",
-				Rules: []string{
-					"https://github.com/konveyor/rules#v1.0/java",
-					"/local/rules",
-					"https://github.com/konveyor/rules2#main",
-				},
 			},
 			wantAppComp: &GitURLComponents{
 				URL:  "https://github.com/konveyor/app",
 				Ref:  "main",
 				Path: "src",
 			},
-			wantRules: 3,
 		},
 		{
-			name: "Local application with Git rules",
+			name: "Local application",
 			config: AnalysisConfig{
 				Application: "/local/app",
-				Rules: []string{
-					"https://github.com/konveyor/rules#main/rulesets",
-				},
 			},
 			wantAppComp: nil,
-			wantRules:   1,
 		},
 		{
-			name: "No rules",
+			name: "Git application with branch only",
 			config: AnalysisConfig{
 				Application: "https://github.com/konveyor/app#main",
-				Rules:       []string{},
 			},
 			wantAppComp: &GitURLComponents{
 				URL: "https://github.com/konveyor/app",
 				Ref: "main",
 			},
-			wantRules: 0,
 		},
 	}
 
@@ -190,11 +177,56 @@ func TestAnalysisConfig_ParseGitURLs(t *testing.T) {
 					t.Error("Expected ApplicationGitComponents to be nil")
 				}
 			}
+		})
+	}
+}
 
-			// Check rules components
-			if len(ac.RulesGitComponents) != tt.wantRules {
-				t.Errorf("RulesGitComponents length = %v, want %v",
-					len(ac.RulesGitComponents), tt.wantRules)
+func TestGitRepoRule_GetCompents(t *testing.T) {
+	tests := []struct {
+		name     string
+		gitRepo  string
+		wantURL  string
+		wantRef  string
+		wantPath string
+	}{
+		{
+			name:     "URL with ref and path",
+			gitRepo:  "https://github.com/konveyor/rules#v1.0/java",
+			wantURL:  "https://github.com/konveyor/rules",
+			wantRef:  "v1.0",
+			wantPath: "java",
+		},
+		{
+			name:     "URL with ref only",
+			gitRepo:  "https://github.com/konveyor/rules#main",
+			wantURL:  "https://github.com/konveyor/rules",
+			wantRef:  "main",
+			wantPath: "",
+		},
+		{
+			name:     "URL with deep path",
+			gitRepo:  "https://github.com/konveyor/rules#main/rulesets/java",
+			wantURL:  "https://github.com/konveyor/rules",
+			wantRef:  "main",
+			wantPath: "rulesets/java",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := GitRepoRule{GitRepo: tt.gitRepo}
+			got := rule.GetCompents()
+			if got == nil {
+				t.Fatal("Expected components to be set")
+			}
+			if got.URL != tt.wantURL {
+				t.Errorf("URL = %v, want %v", got.URL, tt.wantURL)
+			}
+			if got.Ref != tt.wantRef {
+				t.Errorf("Ref = %v, want %v", got.Ref, tt.wantRef)
+			}
+			if got.Path != tt.wantPath {
+				t.Errorf("Path = %v, want %v", got.Path, tt.wantPath)
 			}
 		})
 	}

--- a/pkg/targets/kantra_test.go
+++ b/pkg/targets/kantra_test.go
@@ -2,7 +2,6 @@ package targets
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -791,87 +790,51 @@ func TestKantraTarget_PrepareInputWithBinary(t *testing.T) {
 func TestKantraTarget_PrepareRules(t *testing.T) {
 	tests := []struct {
 		name          string
-		analysis      config.AnalysisConfig
-		expectError   bool
+		rules         []config.CustomRule
 		expectedRules []string
 	}{
 		{
-			name: "no rules",
-			analysis: config.AnalysisConfig{
-				Rules: []string{},
-			},
-			expectError:   false,
+			name:          "no rules",
+			rules:         []config.CustomRule{},
 			expectedRules: nil,
 		},
 		{
-			name: "local rules only",
-			analysis: config.AnalysisConfig{
-				Rules: []string{
-					"/opt/rulesets",
-					"/custom/rules",
-				},
+			name: "absolute file rules",
+			rules: []config.CustomRule{
+				{File: &config.FilePathRule{FilePath: "/opt/rulesets"}},
+				{File: &config.FilePathRule{FilePath: "/custom/rules"}},
 			},
-			expectError: false,
 			expectedRules: []string{
 				"/opt/rulesets",
 				"/custom/rules",
 			},
 		},
 		{
-			name: "Git URL rules",
-			analysis: config.AnalysisConfig{
-				Rules: []string{
-					"https://github.com/konveyor/rulesets#main",
-					"https://github.com/konveyor/analyzer-lsp#v1.0/rules",
-				},
+			name: "relative file rules resolve against test dir",
+			rules: []config.CustomRule{
+				{File: &config.FilePathRule{FilePath: "rules/custom.yaml"}},
 			},
-			expectError: false,
-			// These will be cloned to work directory
 			expectedRules: []string{
-				"testwork/rules-0",
-				"testwork/rules-1",
-			},
-		},
-		{
-			name: "mixed local and Git URL rules",
-			analysis: config.AnalysisConfig{
-				Rules: []string{
-					"/opt/rulesets",
-					"https://github.com/konveyor/rulesets#main/java",
-					"/custom/rules",
-					"https://github.com/konveyor/analyzer-lsp#v1.0/dotnet",
-				},
-			},
-			expectError: false,
-			expectedRules: []string{
-				"/opt/rulesets",
-				"testwork/rules-1",
-				"/custom/rules",
-				"testwork/rules-3",
+				"/testdir/rules/custom.yaml",
 			},
 		},
 	}
 
+	k := &KantraTarget{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Parse Git URLs in the analysis config
-			tt.analysis.ParseGitURLs()
+			cfg := &config.TestDefinition{
+				Analysis: config.AnalysisConfig{
+					Rules: tt.rules,
+				},
+			}
+			cfg.SetTestFilePath("/testdir/test.yaml")
 
-			// Create a mock prepareRules function that simulates the behavior
-			// without actually cloning repositories
-			preparedRules := make([]string, 0, len(tt.analysis.Rules))
-			for i, rule := range tt.analysis.Rules {
-				// Check if we have parsed Git components for this rule
-				if i < len(tt.analysis.RulesGitComponents) && tt.analysis.RulesGitComponents[i] != nil {
-					// Simulate a cloned path
-					preparedRules = append(preparedRules, fmt.Sprintf("testwork/rules-%d", i))
-				} else {
-					// Local path - use as-is
-					preparedRules = append(preparedRules, rule)
-				}
+			preparedRules, err := k.prepareRules(context.Background(), cfg, t.TempDir())
+			if err != nil {
+				t.Fatalf("prepareRules returned error: %v", err)
 			}
 
-			// Verify the results match expected
 			if len(preparedRules) != len(tt.expectedRules) {
 				t.Errorf("Expected %d prepared rules, got %d", len(tt.expectedRules), len(preparedRules))
 			}
@@ -912,47 +875,38 @@ func TestKantraTarget_GitURLIntegration(t *testing.T) {
 			},
 		},
 		{
-			name: "rules with multiple Git URLs and paths",
+			name: "git rules parse into components",
 			analysis: config.AnalysisConfig{
 				Application: "/local/app",
-				Rules: []string{
-					"https://github.com/konveyor/rulesets#main/java",
-					"/local/rules",
-					"https://github.com/konveyor/analyzer-lsp#v1.0/dotnet/rules",
+				Rules: []config.CustomRule{
+					{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/rulesets#main/java"}},
+					{File: &config.FilePathRule{FilePath: "/local/rules"}},
+					{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/analyzer-lsp#v1.0/dotnet/rules"}},
 				},
 			},
 			validate: func(t *testing.T, analysis *config.AnalysisConfig) {
 				if analysis.ApplicationGitComponents != nil {
 					t.Error("Expected ApplicationGitComponents to be nil for local path")
 				}
-				if len(analysis.RulesGitComponents) != 3 {
-					t.Fatalf("Expected 3 RulesGitComponents, got %d", len(analysis.RulesGitComponents))
-				}
 
 				// First rule - Git URL with path
-				if analysis.RulesGitComponents[0] == nil {
-					t.Error("Expected first rule to have Git components")
-				} else {
-					if analysis.RulesGitComponents[0].URL != "https://github.com/konveyor/rulesets" {
-						t.Errorf("First rule URL mismatch: %s", analysis.RulesGitComponents[0].URL)
-					}
-					if analysis.RulesGitComponents[0].Path != "java" {
-						t.Errorf("First rule path mismatch: %s", analysis.RulesGitComponents[0].Path)
-					}
+				components := analysis.Rules[0].Git.GetCompents()
+				if components.URL != "https://github.com/konveyor/rulesets" {
+					t.Errorf("First rule URL mismatch: %s", components.URL)
+				}
+				if components.Path != "java" {
+					t.Errorf("First rule path mismatch: %s", components.Path)
 				}
 
 				// Second rule - local path
-				if analysis.RulesGitComponents[1] != nil {
-					t.Error("Expected second rule to have nil Git components (local path)")
+				if analysis.Rules[1].Git != nil {
+					t.Error("Expected second rule to be a file rule")
 				}
 
 				// Third rule - Git URL with deep path
-				if analysis.RulesGitComponents[2] == nil {
-					t.Error("Expected third rule to have Git components")
-				} else {
-					if analysis.RulesGitComponents[2].Path != "dotnet/rules" {
-						t.Errorf("Third rule path mismatch: %s", analysis.RulesGitComponents[2].Path)
-					}
+				components = analysis.Rules[2].Git.GetCompents()
+				if components.Path != "dotnet/rules" {
+					t.Errorf("Third rule path mismatch: %s", components.Path)
 				}
 			},
 		},

--- a/pkg/targets/tackle_hub_test.go
+++ b/pkg/targets/tackle_hub_test.go
@@ -2,6 +2,8 @@ package targets
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -10,6 +12,13 @@ import (
 )
 
 func TestNewTackleHubTarget(t *testing.T) {
+	// Configs with credentials probe GET /applications at construction time
+	hub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+	}))
+	defer hub.Close()
+
 	tests := []struct {
 		name    string
 		cfg     *config.TackleHubConfig
@@ -23,7 +32,7 @@ func TestNewTackleHubTarget(t *testing.T) {
 		{
 			name: "valid config with token",
 			cfg: &config.TackleHubConfig{
-				URL:   "http://localhost:8080",
+				URL:   hub.URL,
 				Token: "test-token",
 			},
 			wantErr: false,
@@ -31,7 +40,7 @@ func TestNewTackleHubTarget(t *testing.T) {
 		{
 			name: "valid config with username/password",
 			cfg: &config.TackleHubConfig{
-				URL:      "http://localhost:8080",
+				URL:      hub.URL,
 				Username: "admin",
 				Password: "password",
 			},
@@ -40,7 +49,7 @@ func TestNewTackleHubTarget(t *testing.T) {
 		{
 			name: "valid config with maven settings",
 			cfg: &config.TackleHubConfig{
-				URL:           "http://localhost:8080",
+				URL:           hub.URL,
 				MavenSettings: "/path/to/settings.xml",
 			},
 			wantErr: false,
@@ -484,165 +493,102 @@ func TestTackleHubTarget_BinaryModeConfiguration(t *testing.T) {
 func TestTackleHubTarget_PrepareRulesForHub(t *testing.T) {
 	tests := []struct {
 		name        string
-		analysis    config.AnalysisConfig
+		rules       []config.CustomRule
 		expectError bool
 		validate    func(t *testing.T, taskData *Data)
 	}{
 		{
-			name: "no rules",
-			analysis: config.AnalysisConfig{
-				Application: "https://github.com/konveyor/test-app",
-				Rules:       []string{},
-			},
+			name:        "no rules",
+			rules:       []config.CustomRule{},
 			expectError: false,
 			validate: func(t *testing.T, taskData *Data) {
-				if len(taskData.Rules.repositories) != 0 {
-					t.Errorf("Expected no repositories, got %d", len(taskData.Rules.repositories))
+				if taskData.Rules.Path != "" {
+					t.Errorf("Expected no rules path, got %s", taskData.Rules.Path)
 				}
-				if len(taskData.Rules.rules) != 0 {
-					t.Errorf("Expected no rules, got %d", len(taskData.Rules.rules))
+				if taskData.Rules.Repository != nil {
+					t.Errorf("Expected no repository, got %v", taskData.Rules.Repository)
 				}
 			},
 		},
 		{
-			name: "local rules only",
-			analysis: config.AnalysisConfig{
-				Application: "https://github.com/konveyor/test-app",
-				Rules: []string{
-					"/opt/rulesets",
-					"/custom/rules",
-				},
+			name: "file rules only",
+			rules: []config.CustomRule{
+				{File: &config.FilePathRule{FilePath: "/opt/rulesets"}},
+				{File: &config.FilePathRule{FilePath: "/custom/rules"}},
 			},
 			expectError: false,
 			validate: func(t *testing.T, taskData *Data) {
-				if len(taskData.Rules.repositories) != 0 {
-					t.Errorf("Expected no repositories, got %d", len(taskData.Rules.repositories))
+				if taskData.Rules.Path != "/rules" {
+					t.Errorf("Expected rules path /rules, got %s", taskData.Rules.Path)
 				}
-				if len(taskData.Rules.rules) != 2 {
-					t.Errorf("Expected 2 rules, got %d", len(taskData.Rules.rules))
-					return
-				}
-				// Local rules should be in rules list
-				for i, rule := range []string{"/opt/rulesets", "/custom/rules"} {
-					if taskData.Rules.rules[i] != rule {
-						t.Errorf("Expected rule %d to be %s, got %s", i, rule, taskData.Rules.rules[i])
-					}
+				if taskData.Rules.Repository != nil {
+					t.Errorf("Expected no repository, got %v", taskData.Rules.Repository)
 				}
 			},
 		},
 		{
-			name: "Git URL rules",
-			analysis: config.AnalysisConfig{
-				Application: "https://github.com/konveyor/test-app",
-				Rules: []string{
-					"https://github.com/konveyor/rulesets#main",
-					"https://github.com/konveyor/analyzer-lsp#v1.0/rules",
-				},
+			name: "single git rule",
+			rules: []config.CustomRule{
+				{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/rulesets#main/java"}},
 			},
 			expectError: false,
 			validate: func(t *testing.T, taskData *Data) {
-				if len(taskData.Rules.rules) != 0 {
-					t.Errorf("Expected no local rules, got %d", len(taskData.Rules.rules))
+				if taskData.Rules.Repository == nil {
+					t.Fatal("Expected repository to be set")
 				}
-				if len(taskData.Rules.repositories) != 2 {
-					t.Errorf("Expected 2 repositories, got %d", len(taskData.Rules.repositories))
-					return
+				if taskData.Rules.Repository.Kind != "git" {
+					t.Errorf("Expected repository kind git, got %s", taskData.Rules.Repository.Kind)
 				}
-
-				// First rule - Git URL with branch only
-				if taskData.Rules.repositories[0] != "https://github.com/konveyor/rulesets#main" {
-					t.Errorf("Expected first repository to be https://github.com/konveyor/rulesets#main, got %s",
-						taskData.Rules.repositories[0])
+				if taskData.Rules.Repository.URL != "https://github.com/konveyor/rulesets" {
+					t.Errorf("Repository URL mismatch: %s", taskData.Rules.Repository.URL)
 				}
-
-				// Second rule - Git URL with tag and path
-				if taskData.Rules.repositories[1] != "https://github.com/konveyor/analyzer-lsp#v1.0/rules" {
-					t.Errorf("Expected second repository to be https://github.com/konveyor/analyzer-lsp#v1.0/rules, got %s",
-						taskData.Rules.repositories[1])
+				if taskData.Rules.Repository.Branch != "main" {
+					t.Errorf("Repository branch mismatch: %s", taskData.Rules.Repository.Branch)
+				}
+				if taskData.Rules.Repository.Path != "java" {
+					t.Errorf("Repository path mismatch: %s", taskData.Rules.Repository.Path)
 				}
 			},
 		},
 		{
-			name: "mixed local and Git URL rules",
-			analysis: config.AnalysisConfig{
-				Application: "https://github.com/konveyor/test-app",
-				Rules: []string{
-					"/opt/rulesets",
-					"https://github.com/konveyor/rulesets#main/java",
-					"/custom/rules",
-					"https://github.com/konveyor/analyzer-lsp#v1.0/dotnet",
-				},
+			name: "multiple git rules not supported",
+			rules: []config.CustomRule{
+				{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/rulesets#main"}},
+				{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/analyzer-lsp#v1.0"}},
 			},
-			expectError: false,
-			validate: func(t *testing.T, taskData *Data) {
-				if len(taskData.Rules.rules) != 2 {
-					t.Errorf("Expected 2 local rules, got %d", len(taskData.Rules.rules))
-				}
-				if len(taskData.Rules.repositories) != 2 {
-					t.Errorf("Expected 2 repositories, got %d", len(taskData.Rules.repositories))
-				}
-
-				// Check local rules
-				expectedRules := []string{"/opt/rulesets", "/custom/rules"}
-				for i, expected := range expectedRules {
-					if i < len(taskData.Rules.rules) && taskData.Rules.rules[i] != expected {
-						t.Errorf("Expected rule %d to be %s, got %s", i, expected, taskData.Rules.rules[i])
-					}
-				}
-
-				// Check repositories
-				expectedRepos := []string{
-					"https://github.com/konveyor/rulesets#main/java",
-					"https://github.com/konveyor/analyzer-lsp#v1.0/dotnet",
-				}
-				for i, expected := range expectedRepos {
-					if i < len(taskData.Rules.repositories) && taskData.Rules.repositories[i] != expected {
-						t.Errorf("Expected repository %d to be %s, got %s", i, expected, taskData.Rules.repositories[i])
-					}
-				}
+			expectError: true,
+		},
+		{
+			name: "mixed file and git rules not supported",
+			rules: []config.CustomRule{
+				{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/rulesets#main"}},
+				{File: &config.FilePathRule{FilePath: "/opt/rulesets"}},
 			},
+			expectError: true,
 		},
 	}
 
+	target := &TackleHubTarget{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Parse Git URLs
-			tt.analysis.ParseGitURLs()
-
-			// Create test definition with the analysis
 			test := &config.TestDefinition{
-				Analysis: tt.analysis,
-			}
-
-			// Create task data
-			taskData := &Data{
-				Rules: Rules{
-					repositories: make([]string, 0),
-					rules:        make([]string, 0),
+				Analysis: config.AnalysisConfig{
+					Application: "https://github.com/konveyor/test-app",
+					Rules:       tt.rules,
 				},
 			}
+			taskData := &Data{}
 
-			// Simulate prepareRulesForHub logic
-			for i, rule := range test.Analysis.Rules {
-				// Check if we have parsed Git components for this rule
-				if i < len(test.Analysis.RulesGitComponents) && test.Analysis.RulesGitComponents[i] != nil {
-					// Git URL - add to repositories
-					components := test.Analysis.RulesGitComponents[i]
-					repoString := components.URL
-					if components.Ref != "" {
-						repoString += "#" + components.Ref
-						if components.Path != "" {
-							repoString += "/" + components.Path
-						}
-					}
-					taskData.Rules.repositories = append(taskData.Rules.repositories, repoString)
-				} else {
-					// Local path - add to rules
-					taskData.Rules.rules = append(taskData.Rules.rules, rule)
+			err := target.prepareRulesForHub(context.Background(), test, taskData)
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected an error")
 				}
+				return
 			}
-
-			// Run validation
+			if err != nil {
+				t.Fatalf("prepareRulesForHub returned error: %v", err)
+			}
 			tt.validate(t, taskData)
 		})
 	}
@@ -697,47 +643,38 @@ func TestTackleHubTarget_GitURLIntegration(t *testing.T) {
 			name: "rules with Git URLs containing paths",
 			analysis: config.AnalysisConfig{
 				Application: "/local/app",
-				Rules: []string{
-					"https://github.com/konveyor/rulesets#main/java/cloud-readiness",
-					"https://github.com/konveyor/analyzer-lsp#v2.0/dotnet/migration",
+				Rules: []config.CustomRule{
+					{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/rulesets#main/java/cloud-readiness"}},
+					{Git: &config.GitRepoRule{GitRepo: "https://github.com/konveyor/analyzer-lsp#v2.0/dotnet/migration"}},
 				},
 			},
 			validate: func(t *testing.T, analysis *config.AnalysisConfig) {
 				if analysis.ApplicationGitComponents != nil {
 					t.Error("Expected ApplicationGitComponents to be nil for local path")
 				}
-				if len(analysis.RulesGitComponents) != 2 {
-					t.Fatalf("Expected 2 RulesGitComponents, got %d", len(analysis.RulesGitComponents))
-				}
 
 				// First rule
-				if analysis.RulesGitComponents[0] == nil {
-					t.Error("Expected first rule to have Git components")
-				} else {
-					if analysis.RulesGitComponents[0].URL != "https://github.com/konveyor/rulesets" {
-						t.Errorf("First rule URL mismatch: %s", analysis.RulesGitComponents[0].URL)
-					}
-					if analysis.RulesGitComponents[0].Ref != "main" {
-						t.Errorf("First rule ref mismatch: %s", analysis.RulesGitComponents[0].Ref)
-					}
-					if analysis.RulesGitComponents[0].Path != "java/cloud-readiness" {
-						t.Errorf("First rule path mismatch: %s", analysis.RulesGitComponents[0].Path)
-					}
+				components := analysis.Rules[0].Git.GetCompents()
+				if components.URL != "https://github.com/konveyor/rulesets" {
+					t.Errorf("First rule URL mismatch: %s", components.URL)
+				}
+				if components.Ref != "main" {
+					t.Errorf("First rule ref mismatch: %s", components.Ref)
+				}
+				if components.Path != "java/cloud-readiness" {
+					t.Errorf("First rule path mismatch: %s", components.Path)
 				}
 
 				// Second rule
-				if analysis.RulesGitComponents[1] == nil {
-					t.Error("Expected second rule to have Git components")
-				} else {
-					if analysis.RulesGitComponents[1].URL != "https://github.com/konveyor/analyzer-lsp" {
-						t.Errorf("Second rule URL mismatch: %s", analysis.RulesGitComponents[1].URL)
-					}
-					if analysis.RulesGitComponents[1].Ref != "v2.0" {
-						t.Errorf("Second rule ref mismatch: %s", analysis.RulesGitComponents[1].Ref)
-					}
-					if analysis.RulesGitComponents[1].Path != "dotnet/migration" {
-						t.Errorf("Second rule path mismatch: %s", analysis.RulesGitComponents[1].Path)
-					}
+				components = analysis.Rules[1].Git.GetCompents()
+				if components.URL != "https://github.com/konveyor/analyzer-lsp" {
+					t.Errorf("Second rule URL mismatch: %s", components.URL)
+				}
+				if components.Ref != "v2.0" {
+					t.Errorf("Second rule ref mismatch: %s", components.Ref)
+				}
+				if components.Path != "dotnet/migration" {
+					t.Errorf("Second rule path mismatch: %s", components.Path)
 				}
 			},
 		},

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -59,6 +59,16 @@ func getComparer(targetType, testDir string) comparer {
 	return nil
 }
 
+// isSynthesizedTagRuleset reports whether rs is one of the rulesets the
+// tackle-hub target fabricates from application tags and contains nothing
+// but tags.
+func isSynthesizedTagRuleset(rs konveyor.RuleSet) bool {
+	if rs.Name != "discovery-rules" && rs.Name != "technology-usage" {
+		return false
+	}
+	return len(rs.Violations) == 0 && len(rs.Insights) == 0 && len(rs.Errors) == 0
+}
+
 // ValidationResult contains the result of validation
 type ValidationResult struct {
 	Passed bool
@@ -184,13 +194,22 @@ func ValidateFiles(testDir, targetType string, actual, expected []konveyor.RuleS
 		expectedRulesetNames[expectedRulesetName] = true
 	}
 	for _, rs := range actual {
-		if !expectedRulesetNames[rs.Name] {
-			errors = append(errors, ValidationError{
-				Path:    fmt.Sprintf("ruleset/%s", rs.Name),
-				Message: fmt.Sprintf("Unexpected ruleset found: %s", rs.Name),
-				Actual:  rs.Name,
-			})
+		if expectedRulesetNames[rs.Name] {
+			continue
 		}
+		// The tackle-hub target synthesizes discovery-rules/technology-usage
+		// rulesets from the hub's discovery-task tags, which have no kantra
+		// equivalent and whose presence depends on discovery-task timing.
+		// Tags are never compared for tackle-hub, so a tag-only synthesized
+		// ruleset carries no comparable content and is not a failure.
+		if targetType == "tackle-hub" && isSynthesizedTagRuleset(rs) {
+			continue
+		}
+		errors = append(errors, ValidationError{
+			Path:    fmt.Sprintf("ruleset/%s", rs.Name),
+			Message: fmt.Sprintf("Unexpected ruleset found: %s", rs.Name),
+			Actual:  rs.Name,
+		})
 	}
 
 	// If not equal, generate detailed diff

--- a/pkg/validator/validator_test.go
+++ b/pkg/validator/validator_test.go
@@ -241,6 +241,69 @@ func TestValidateFiles_WithTargetType(t *testing.T) {
 	}
 }
 
+func TestValidateFiles_HubSynthesizedDiscoveryRulesets(t *testing.T) {
+	expected := []konveyor.RuleSet{
+		{
+			Name: "dotnet-core-migration",
+			Violations: map[string]konveyor.Violation{
+				"rule1": {Description: "Test"},
+			},
+		},
+	}
+
+	actual := []konveyor.RuleSet{
+		{
+			Name: "dotnet-core-migration",
+			Violations: map[string]konveyor.Violation{
+				"rule1": {Description: "Test"},
+			},
+		},
+		{
+			Name: "technology-usage",
+			Tags: []string{".NET", "ASP.NET"},
+		},
+		{
+			Name: "discovery-rules",
+			Tags: []string{"C#", "JavaScript"},
+		},
+	}
+
+	// Tag-only synthesized rulesets must not fail hub validation, since their
+	// presence depends on discovery-task timing and tags are never compared
+	result, err := ValidateFiles("/test", "tackle-hub", actual, expected)
+	if err != nil {
+		t.Fatalf("ValidateFiles returned error: %v", err)
+	}
+	if !result.Passed {
+		t.Errorf("Expected tackle-hub validation to pass, got errors: %v", result.Errors)
+	}
+
+	// Other targets still report them as unexpected
+	result, err = ValidateFiles("/test", "kantra", actual, expected)
+	if err != nil {
+		t.Fatalf("ValidateFiles returned error: %v", err)
+	}
+	if result.Passed {
+		t.Error("Expected kantra validation to fail on unexpected rulesets")
+	}
+
+	// A synthesized-name ruleset that carries real content is still unexpected
+	actual = append(actual[:1], konveyor.RuleSet{
+		Name: "technology-usage",
+		Tags: []string{".NET"},
+		Insights: map[string]konveyor.Violation{
+			"tag-rule": {Description: "Test"},
+		},
+	})
+	result, err = ValidateFiles("/test", "tackle-hub", actual, expected)
+	if err != nil {
+		t.Fatalf("ValidateFiles returned error: %v", err)
+	}
+	if result.Passed {
+		t.Error("Expected tackle-hub validation to fail when synthesized ruleset has insights")
+	}
+}
+
 // Helper functions
 func intPtr(i int) *int {
 	return &i


### PR DESCRIPTION
## Summary

Fixes the race reported by @mguetta1  where hub-target tests fail with `Unexpected ruleset found: technology-usage` depending on discovery-task timing (nerd-dinner, locally flaky while nightly stays green).

**Root cause:** the tackle-hub target synthesizes `discovery-rules`/`technology-usage` rulesets from the hub's discovery-task tags (no kantra equivalent, and tag contents are never compared for the hub target). koncur only waits on the analysis task, and empty rulesets are filtered before validation — so if tech-discovery finishes before the tag snapshot the synthesized ruleset survives with tags and trips the shared unexpected-ruleset check; if not, it's filtered and the test passes. Only C# is affected because the kantra-generated expected output for nerd-dinner has no `technology-usage` ruleset (all Java expected outputs do).

**Fix:** the unexpected-ruleset check now skips `discovery-rules`/`technology-usage` for tackle-hub when the ruleset contains nothing but tags. Rulesets with real content (violations/insights/errors) still fail, and the missing-ruleset direction is unchanged. Historical hub outputs show insight reporting for tagging rules has varied across hub versions, so tolerating the fabricated tag-only ruleset is the only behavior correct under all observed variants (as opposed to dropping the tag collection, which would break Java tests on hubs that don't report tagging insights).

## Also: unit tests now run in CI

While verifying, we found no CI job runs `go test` — the unit tests in `pkg/config` and `pkg/targets` have been uncompilable since the `CustomRule` refactor (#44, ~4 months) without anyone noticing.

- Updated rule-handling tests to the `CustomRule` model; rewrote `prepareRules`/`prepareRulesForHub` tests to exercise the real methods (including the hub's one-git-repo and no-mixed-rules error paths) instead of simulating removed logic
- `TestNewTackleHubTarget` now stubs the login probe with `httptest` instead of retrying against `localhost:8080` for 3 minutes
- New `unit-tests` job (`go vet ./...` + `go test ./...`) in the PR CI workflow

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green (pkg/targets down from 180s of network retries to <1s)
- [x] New `TestValidateFiles_HubSynthesizedDiscoveryRulesets` covers the exact failure shape: tag-only `technology-usage` absent from expected passes for tackle-hub, still fails for kantra, and a synthesized-name ruleset with insights still fails
- [ ] Hub nightly on this branch (validator change only relaxes the one fabricated-data check, so Java tests are unaffected by construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of discovered rulesets so tag-only synthesized rulesets are accepted for hub-based validation, while real content still triggers validation errors.
  * Made rule URL and path parsing more reliable for both Git-based and local file rules.

* **Tests**
  * Expanded coverage for ruleset validation and rule parsing across hub and Kantra scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->