### PR TITLE
Add OPERATOR_REF variable to match operator branch with images under test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ KUBECTL ?= kubectl
 HOST_PORT ?= 8080
 HOST_PORT_TLS ?= 8443
 IMAGE_TAG ?= latest
+OPERATOR_REF ?= main
 
 # Image FQINs with defaults
 HUB ?= quay.io/konveyor/tackle2-hub:$(IMAGE_TAG)
@@ -102,8 +103,8 @@ _hub-install: ## Internal target for hub installation
 	@$(KUBECTL) delete pod -n olm -l olm.catalogSource=operatorhubio-catalog --ignore-not-found=true || true
 	@sleep 5
 	@$(KUBECTL) wait --for=condition=ready pod -l olm.catalogSource=operatorhubio-catalog -n olm --timeout=120s || true
-	@echo "Installing Tackle operator from main branch..."
-	@$(KUBECTL) apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml
+	@echo "Installing Tackle operator from $(OPERATOR_REF) branch..."
+	@$(KUBECTL) apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/$(OPERATOR_REF)/tackle-k8s.yaml
 	@echo "Waiting for Tackle CRD to be available..."
 	@for i in $$(seq 1 120); do \
 		$(KUBECTL) get crd tackles.tackle.konveyor.io >/dev/null 2>&1 && break || sleep 5; \


### PR DESCRIPTION
## Summary

Fixes the version skew issue where the koncur Makefile always deploys the Tackle operator from `main` branch, even when testing release branches.

## Problem

The `_hub-install` target hardcoded the operator deployment:
```makefile
@$(KUBECTL) apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/main/tackle-k8s.yaml
```

This causes CI failures when testing release branches (e.g., release-0.9):

**Version Skew:**
- 🔴 **Operator:** Deployed from `main` (uses built-in OIDC, no Keycloak)
- 🟡 **Hub Image:** From `release-0.9` (expects Keycloak at `https://localhost:8081/auth/realms/master`)
- 🟡 **CI Auth:** From `release-0.9` (waits for Keycloak pod)
- **Result:** Hub API never serves → HTTP 000 → timeout

## Solution

Add `OPERATOR_REF` variable that:
- Defaults to `main` (preserves current behavior)
- Can be overridden by CI to match the branch being tested

```makefile
OPERATOR_REF ?= main
...
@$(KUBECTL) apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/$(OPERATOR_REF)/tackle-k8s.yaml
```

## Changes

- Added `OPERATOR_REF ?= main` configuration variable
- Updated `_hub-install` target to use `$(OPERATOR_REF)`
- Updated echo message to show which branch is being deployed

## Testing

Manual test:
```bash
# Default behavior (main)
make hub-install-auth

# Override for release branch
OPERATOR_REF=release-0.9 make hub-install-auth
```

## Companion PR

This requires a companion PR in konveyor/ci to pass `OPERATOR_REF` based on the branch being tested.

## References

- Fixes #113
- Evidence: [analyzer-lsp Run 32134695641](https://github.com/konveyor/analyzer-lsp/actions/runs/32134695641)