### PR TITLE
Fix CatalogSource image tag to match OPERATOR_REF branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ _hub-install: ## Internal target for hub installation
 	@$(KUBECTL) wait --for=condition=ready pod -l olm.catalogSource=operatorhubio-catalog -n olm --timeout=120s || true
 	@echo "Installing Tackle operator from $(OPERATOR_REF) branch..."
 	@$(KUBECTL) apply -f https://raw.githubusercontent.com/konveyor/tackle2-operator/$(OPERATOR_REF)/tackle-k8s.yaml
+	@echo "Patching CatalogSource to use operator-index:$(OPERATOR_REF)..."
+	@$(KUBECTL) patch catalogsource konveyor -n ${KONVEYOR_NAMESPACE} --type=merge \
+		-p '{"spec":{"image":"quay.io/konveyor/tackle2-operator-index:$(OPERATOR_REF)"}}'
 	@echo "Waiting for Tackle CRD to be available..."
 	@for i in $$(seq 1 120); do \
 		$(KUBECTL) get crd tackles.tackle.konveyor.io >/dev/null 2>&1 && break || sleep 5; \


### PR DESCRIPTION
## Problem

The `tackle-k8s.yaml` manifest on release branches (release-0.9, release-0.10, etc.) hardcodes the CatalogSource image to `tackle2-operator-index:latest`, which causes OLM to install the **main branch operator** even when testing release branches.

This creates a version mismatch:
- Main operator uses built-in OIDC (no Keycloak)
- Release-0.9 hub expects Keycloak
- Hub tries to connect to `localhost:8081/auth/...` → connection refused
- Hub API never becomes ready → CI test timeout

Example failure: https://github.com/konveyor/analyzer-lsp/actions/runs/33755983498/job/102863877777

## Root Cause

The `tackle-k8s.yaml` file on release branches has:
```yaml
kind: CatalogSource
spec:
  image: quay.io/konveyor/tackle2-operator-index:latest  # ← Hardcoded!
```

Even though koncur correctly fetches the manifest from the release branch using `OPERATOR_REF`, the catalog source inside that manifest points to `:latest`, which pulls the main operator.

## Solution

After applying `tackle-k8s.yaml`, immediately patch the CatalogSource to use the operator-index image tag matching `OPERATOR_REF`:

```makefile
@echo "Patching CatalogSource to use operator-index:$(OPERATOR_REF)..."
@$(KUBECTL) patch catalogsource konveyor -n ${KONVEYOR_NAMESPACE} --type=merge \
  -p '{"spec":{"image":"quay.io/konveyor/tackle2-operator-index:$(OPERATOR_REF)"}}'
```

## Examples

**Testing release-0.9:**
- `OPERATOR_REF=release-0.9`
- Patches CatalogSource to: `tackle2-operator-index:release-0.9`
- OLM installs release-0.9 operator (with Keycloak) ✅
- Hub works correctly ✅

**Testing main:**
- `OPERATOR_REF=main`
- Patches CatalogSource to: `tackle2-operator-index:main`
- OLM installs main operator ✅
- Hub works correctly ✅

## Impact

✅ Fixes koncur-tackle-hub test failures on **all release branches**
✅ No impact on main branch tests (still works)
✅ Future-proof for any new release branches
✅ Backward compatible

## Related

Fixes https://github.com/konveyor/ci/issues/261 (second part - first part was https://github.com/konveyor/ci/pull/260)

## Test Plan

Once merged:
- Re-run any failing release-0.9 or release-0.10 PRs
- koncur-tackle-hub test should pass
- Verify operator pods are from correct branch

cc @djzager